### PR TITLE
Luacheck workflow, Ubuntu 20.04 deprecated

### DIFF
--- a/.github/workflows/luacheck.yml
+++ b/.github/workflows/luacheck.yml
@@ -1,18 +1,10 @@
 name: luacheck
-
 on: [push, pull_request]
-
 jobs:
-  build:
-
-    runs-on: ubuntu-20.04
-    timeout-minutes: 10
-
+  luacheck:
+    runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - name: apt
-      run: sudo apt-get install -y luarocks
-    - name: luacheck install
-      run: luarocks install --local luacheck
-    - name: luacheck run
-      run: $HOME/.luarocks/bin/luacheck ./
+      - name: Checkout
+        uses: actions/checkout@master
+      - name: Luacheck
+        uses: lunarmodules/luacheck@master


### PR DESCRIPTION
Luacheck stuck waiting for worker it never gets because Ubuntu 20.04 has been removed.
Updated to "standard" luacheck workflow.

* Also for #7 